### PR TITLE
OP-3896: Allow Optional TF Variable ephemeral_storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ module "function" {
 | <a name="input_dead_letter_config"></a> [dead\_letter\_config](#input\_dead\_letter\_config) | n/a | <pre>object({<br>    target_arn = string<br>  })</pre> | `null` | no |
 | <a name="input_description"></a> [description](#input\_description) | A description for this Lambda Function | `string` | `"Created by Terraform"` | no |
 | <a name="input_env_vars"></a> [env\_vars](#input\_env\_vars) | A map that defines environment variables for this Lambda function. | `map` | `null` | no |
+| <a name="input_ephemeral_storage"></a> [ephemeral\_storage](#input\_ephemeral\_storage) | Amount of Ephemeral storage(/tmp) in MB this Lambda Function can use at runtime. Defaults to 512 | `number` | `512` | no |
 | <a name="input_filename"></a> [filename](#input\_filename) | The zip file to upload containing the function code | `string` | `""` | no |
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | A unique name for this Lambda Function | `string` | n/a | yes |
 | <a name="input_handler"></a> [handler](#input\_handler) | The function entrypoint. Only specify when var.package\_type is Zip | `string` | `"lambda_function.lambda_handler"` | no |

--- a/main.tf
+++ b/main.tf
@@ -53,6 +53,9 @@ resource "aws_lambda_function" "lambda" {
     var.layers :
     null
   )
+  ephemeral_storage = {
+    size = var.ephemeral_storage
+  }
   package_type = var.package_type
   // Use empty_function.zip if no other file is specified
   filename = var.package_type == "Zip" ? length(var.filename) > 0 ? var.filename : "${path.module}/files/empty_function.zip" : null

--- a/main.tf
+++ b/main.tf
@@ -53,13 +53,14 @@ resource "aws_lambda_function" "lambda" {
     var.layers :
     null
   )
-  ephemeral_storage = {
-    size = var.ephemeral_storage
-  }
   package_type = var.package_type
   // Use empty_function.zip if no other file is specified
   filename = var.package_type == "Zip" ? length(var.filename) > 0 ? var.filename : "${path.module}/files/empty_function.zip" : null
   image_uri = var.package_type == "Image" ? var.image_uri : null
+
+  ephemeral_storage {
+    size = var.ephemeral_storage
+  }
 
   dynamic "environment" {
     for_each = local.env_vars

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,11 @@ variable "memory_size" {
   description = "Amount of memory in MB this Lambda Function can use at runtime. Defaults to 128"
 }
 
+variable "ephemeral_storage" {
+  default     = 512
+  description = "Amount of Ephemeral storage(/tmp) in MB this Lambda Function can use at runtime. Defaults to 512"
+}
+
 variable "timeout" {
   default     = 5
   description = "The amount of time this Lambda Function has to run in seconds"


### PR DESCRIPTION
#### PR description

What is it for?
The PR is to allow optional TF variable `ephemeral_storage` in AWS lambda function resource.

#### Testing instructions
- Verify that the new lambda version supports `ephemeral_storage` block in `aws_lambda_function` resource.

#### JIRA ticket information
Story: [OP-3896](https://globeandmail.atlassian.net/browse/OP-3896)

[OP-3896]: https://globeandmail.atlassian.net/browse/OP-3896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ